### PR TITLE
LL-29

### DIFF
--- a/controller/README.md
+++ b/controller/README.md
@@ -52,3 +52,19 @@ as the problematic import statement to ignore the error for that specific line:
 `# pylint: disable=E0401`
 
 [E0401](https://pylint.pycqa.org/en/latest/user_guide/messages/error/import-error.html) is pylint's error alerting you that it was unable to import a package.
+
+### Connecting the Pico W to Wifi https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.pdf
+For a simple connection to a local WiFi network, you can use the following code:
+```
+import network
+wlan = network.WLAN(network.STA_IF) # constructs a client interface object
+wlan.active(True) # activates the network interface ("up")
+wlan.connect(ssid, password) # connects to the given wifi network using given credentials
+```
+For creating a more robust connection, see [the Pico W documentation](https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.pdf).
+
+### Querying the Wifi Connection State
+To querry the Wifi connection state, simply use the following method on the network interface object:
+`wlan.isconnected()`
+
+This returns true if the interface is connected, otherwise false.


### PR DESCRIPTION
# Description

This was a proof-of-concept that the MCU's connection state can be displayed. The documentation under `controller/README.md` has been updated to show how to connect to a local WiFi network and how to query the state of the connection. This can be accomplished by accessing the MCU's micropython REPL via serial connection and running the code in the readme. From here, an API can be constructed to allow for a robust WiFi connection, with querying capabilities.

## Type of change

Please delete options that are not relevant.

- [X] Proof of concept (update to documentation)

# How Has This Been Tested?

Testing was done directly in a micropython REPL on a Raspberry Pi Pico W. Here is a screenshot of the test:

![LL-29 Screenshot](https://user-images.githubusercontent.com/25559473/210191041-a0389335-3572-43a7-8864-c16b7f92b6ff.png)

# Checklist (when relevant):

- [X] My code follows the style guidelines of this project

    [TypeScript](https://google.github.io/styleguide/tsguide.html)
[Python](https://peps.python.org/pep-0008/)
[Schema](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/forefront-2010/ee652242(v=vs.100))
- [X] I have included a reviewer on the pull request [Aaron]
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [ ] New and existing unit tests pass locally with my changes (N/A)
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)